### PR TITLE
fix: make devcontainer.json valid for schema validation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,21 +1,9 @@
 {
   "name": "Python 3 Development Container Template",
-  "dockerFile": "Dockerfile",
-
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
   "customizations": {
-    "settings": {
-      "files.eol": "\n",
-      "editor.formatOnSave": true,
-      "python.testing.pytestArgs": ["."],
-      "python.testing.unittestEnabled": false,
-      "python.testing.pytestEnabled": true,
-      "python.formatting.provider": "black",
-      "python.linting.mypyEnabled": true,
-      "python.linting.enabled": true,
-      "remote.extensionKind": {
-        "ms-azuretools.vscode-docker": "workspace"
-      }
-    },
     "vscode": {
       "extensions": [
         "davidanson.vscode-markdownlint",
@@ -30,16 +18,18 @@
         "vscode-icons-team.vscode-icons"
       ],
       "settings": {
-        "workbench.iconTheme": "vscode-icons"
+        "files.eol": "\n",
+        "editor.formatOnSave": true,
+        "python.testing.pytestArgs": ["."],
+        "python.testing.unittestEnabled": false,
+        "python.testing.pytestEnabled": true,
+        "workbench.iconTheme": "vscode-icons",
+        "remote.extensionKind": {
+          "ms-azuretools.vscode-docker": "workspace"
+        }
       }
     }
   },
-
   "postCreateCommand": ".devcontainer/scripts/postCreate.sh",
-
-  // Use 'forwardPorts' to make a list of ports inside the container available locally.
-  // "forwardPorts": [],
-
-  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   "remoteUser": "root"
 }


### PR DESCRIPTION
## Summary
- Remove JSONC comments that break strict JSON parsing
- Replace legacy \`dockerFile\` with \`build.dockerfile\`
- Nest settings under \`customizations.vscode\`

## Test plan
- [ ] \`validate-devschema\` passes

Closes #12